### PR TITLE
fix: remediate Okta connector findings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ default_stages: [pre-commit]
 # This is a template for connector pre-commit hooks
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [--verbose]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -27,13 +27,13 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+    rev: v0.15.22
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.36.4
+    rev: v1.40.7
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -43,12 +43,12 @@ repos:
       - id: soar-app-linter
         args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
-    rev: 0.7.22
+    rev: 1.0.0
     hooks:
       - id: mdformat
         exclude: "release_notes/.*"
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.136.0
+    rev: v1.165.0
     hooks:
       - id: semgrep
         additional_dependencies: ["setuptools==81.0.0"]
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.1.6
     hooks:
       - id: build-docs
         language: python

--- a/README.md
+++ b/README.md
@@ -420,7 +420,6 @@ DATA PATH | TYPE | CONTAINS | EXAMPLE VALUES
 action_result.status | string | | success failed |
 action_result.parameter.receive_type | string | | UI |
 action_result.parameter.user_id | string | `okta user id` | 00uby4va2hynIj0mS0h7 |
-action_result.data.\*.resetPasswordUrl | string | `url` | https://your-org.okta.com/reset_password/s-HbbqSmqoCLn0pdYTzx |
 action_result.summary | string | | |
 action_result.message | string | | Successfully created one-time token for user to reset password |
 summary.total_objects | numeric | | 1 |
@@ -769,7 +768,6 @@ action_result.data.\*.policy.subject.matchAttribute | string | | |
 action_result.data.\*.policy.subject.matchType | string | | USERNAME_OR_EMAIL |
 action_result.data.\*.policy.subject.userNameTemplate.template | string | | idpuser.userPrincipalName |
 action_result.data.\*.protocol.credentials.client.client_id | string | | 2904b0a4-ebb7-42db-9d35-3280c656c121 |
-action_result.data.\*.protocol.credentials.client.client_secret | string | | qw8y7gztT5DznvmPfmdEmHo |
 action_result.data.\*.protocol.endpoints.authorization.binding | string | | HTTP-REDIRECT |
 action_result.data.\*.protocol.endpoints.authorization.url | string | `url` | https://login.microsoftonline.com/common/oauth2/v2.0/authorize |
 action_result.data.\*.protocol.endpoints.token.binding | string | | HTTP-POST |

--- a/README.md
+++ b/README.md
@@ -420,6 +420,7 @@ DATA PATH | TYPE | CONTAINS | EXAMPLE VALUES
 action_result.status | string | | success failed |
 action_result.parameter.receive_type | string | | UI |
 action_result.parameter.user_id | string | `okta user id` | 00uby4va2hynIj0mS0h7 |
+action_result.data.\*.resetPasswordUrl | string | `url` | https://your-org.okta.com/reset_password/s-HbbqSmqoCLn0pdYTzx |
 action_result.summary | string | | |
 action_result.message | string | | Successfully created one-time token for user to reset password |
 summary.total_objects | numeric | | 1 |

--- a/display_add_group.html
+++ b/display_add_group.html
@@ -96,7 +96,7 @@
               <th>ID</th>
               <td>
                 <a href="javascript:;"
-                   onclick="context_menu(this, [{'contains': ['okta group id'], 'value': '{{ curr_data.id }}' }], 0, {{ container.id }}, null, false);">
+                   onclick="context_menu(this, [{'contains': ['okta group id'], 'value': '{{ curr_data.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                   {{ curr_data.id }}
                   &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                 </a>

--- a/display_get_group.html
+++ b/display_get_group.html
@@ -109,7 +109,7 @@
                 <td>
                   <a class="no-word-wrap"
                      href="javascript:;"
-                     onclick="context_menu(this, [{'contains': ['okta group id'], 'value': '{{ curr_data.id }}' }], 0, {{ container.id }}, null, false);">
+                     onclick="context_menu(this, [{'contains': ['okta group id'], 'value': '{{ curr_data.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                     {{ curr_data.id }}
                     &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                   </a>

--- a/display_get_user.html
+++ b/display_get_user.html
@@ -123,7 +123,7 @@
                 <td>
                   <a href="javascript:;"
                      class="no-word-wrap"
-                     onclick="context_menu(this, [{'contains': ['okta user id'], 'value': '{{ curr_data.id }}' }], 0, {{ container.id }}, null, false);">
+                     onclick="context_menu(this, [{'contains': ['okta user id'], 'value': '{{ curr_data.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                     {{ curr_data.id }}
                     &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                   </a>

--- a/display_identity_providers.html
+++ b/display_identity_providers.html
@@ -131,7 +131,7 @@
               <td>{{ curr_idps.protocol.endpoints.token.binding }}</td>
               <td>
                 <a href="javascript:;"
-                   onclick="context_menu(this, [{'contains': ['url'], 'value': '{{ curr_idps.protocol.endpoints.token.url }}' }], 0, {{ container.id }}, null, false);">
+                   onclick="context_menu(this, [{'contains': ['url'], 'value': '{{ curr_idps.protocol.endpoints.token.url|escapejs }}' }], 0, {{ container.id }}, null, false);">
                   {{ curr_idps.protocol.endpoints.token.url }}
                   &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                 </a>
@@ -142,7 +142,7 @@
               <td>{{ curr_idps.protocol.endpoints.authorization.binding }}</td>
               <td>
                 <a href="javascript:;"
-                   onclick="context_menu(this, [{'contains': ['url'], 'value': '{{ curr_idps.protocol.endpoints.authorization.url }}' }], 0, {{ container.id }}, null, false);">
+                   onclick="context_menu(this, [{'contains': ['url'], 'value': '{{ curr_idps.protocol.endpoints.authorization.url|escapejs }}' }], 0, {{ container.id }}, null, false);">
                   {{ curr_idps.protocol.endpoints.authorization.url }}
                   &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                 </a>

--- a/display_list_user.html
+++ b/display_list_user.html
@@ -108,7 +108,7 @@
                   <td>
                     <a class="no-word-wrap"
                        href="javascript:;"
-                       onclick="context_menu(this, [{'contains': ['okta user id'], 'value': '{{ curr_data.id }}' }], 0, {{ container.id }}, null, false);">
+                       onclick="context_menu(this, [{'contains': ['okta user id'], 'value': '{{ curr_data.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                       {{ curr_data.id }}
                       &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                     </a>

--- a/display_list_user_groups.html
+++ b/display_list_user_groups.html
@@ -94,7 +94,7 @@
               <th>ID</th>
               <td>
                 <a href="javascript:;"
-                   onclick="context_menu(this, [{'contains': ['okta group id'], 'value': '{{ curr_data.id }}' }], 0, {{ container.id }}, null, false);">
+                   onclick="context_menu(this, [{'contains': ['okta group id'], 'value': '{{ curr_data.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                   {{ curr_data.id }}
                   &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                 </a>

--- a/display_set_password.html
+++ b/display_set_password.html
@@ -94,7 +94,7 @@
               <th>ID</th>
               <td>
                 <a href="javascript:;"
-                   onclick="context_menu(this, [{'contains': ['okta group id'], 'value': '{{ curr_data.id }}' }], 0, {{ container.id }}, null, false);">
+                   onclick="context_menu(this, [{'contains': ['okta group id'], 'value': '{{ curr_data.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                   {{ curr_data.id }}
                   &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                 </a>

--- a/okta.json
+++ b/okta.json
@@ -37,7 +37,7 @@
         "verify_server_cert": {
             "description": "Verify server certificate",
             "data_type": "boolean",
-            "default": false,
+            "default": true,
             "order": 2
         }
     },

--- a/okta.json
+++ b/okta.json
@@ -3109,13 +3109,6 @@
                     "data_type": "string"
                 },
                 {
-                    "data_path": "action_result.data.*.protocol.credentials.client.client_secret",
-                    "example_values": [
-                        "qw8y7gztT5DznvmPfmdEmHo"
-                    ],
-                    "data_type": "string"
-                },
-                {
                     "data_path": "action_result.data.*.protocol.endpoints.authorization.binding",
                     "example_values": [
                         "HTTP-REDIRECT"

--- a/okta_connector.py
+++ b/okta_connector.py
@@ -544,10 +544,6 @@ class OktaConnector(BaseConnector):
         ret_val, response = self._make_rest_call(f"/users/{quote(str(user_id), safe='')}/sessions", action_result, method="delete")
 
         if phantom.is_fail(ret_val):
-            message = action_result.get_message()
-            if "Empty response and no information in the header" == message:
-                # This occurs because the delete call in the Okta API only returns a 204 success
-                return action_result.set_status(phantom.APP_SUCCESS, OKTA_CLEAR_USER_SESSIONS_SUCC)
             return action_result.get_status()
 
         # Add the response into the data section

--- a/okta_connector.py
+++ b/okta_connector.py
@@ -525,6 +525,15 @@ class OktaConnector(BaseConnector):
                 )
             return action_result.get_status()
 
+        revoke_ret_val, _revoke_response = self._make_rest_call(
+            f"/users/{quote(str(user_id), safe='')}/sessions",
+            action_result,
+            params={"oauthTokens": True},
+            method="delete",
+        )
+        if phantom.is_fail(revoke_ret_val):
+            return action_result.set_status(phantom.APP_ERROR, "User was suspended, but existing sessions or OAuth tokens could not be revoked")
+
         # Add the response into the data section
         action_result.add_data(response)
 

--- a/okta_connector.py
+++ b/okta_connector.py
@@ -509,7 +509,20 @@ class OktaConnector(BaseConnector):
         if phantom.is_fail(ret_val):
             message = action_result.get_message()
             if "Cannot suspend a user that is not active" in message:
-                return action_result.set_status(phantom.APP_SUCCESS, OKTA_ALREADY_DISABLED_USER_ERR)
+                status_ret_val, user_response = self._make_rest_call(f"/users/{quote(str(user_id), safe='')}", action_result)
+                user_status = user_response.get("status") if phantom.is_success(status_ret_val) and isinstance(user_response, dict) else None
+                if user_status in ("SUSPENDED", "DEPROVISIONED"):
+                    action_result.update_summary({"user_status": user_status})
+                    return action_result.set_status(phantom.APP_SUCCESS, OKTA_ALREADY_DISABLED_USER_ERR)
+                if user_status:
+                    action_result.update_summary({"user_status": user_status})
+                    return action_result.set_status(
+                        phantom.APP_ERROR,
+                        f"User could not be suspended: current lifecycle status is {user_status}. The user is not disabled.",
+                    )
+                return action_result.set_status(
+                    phantom.APP_ERROR, "User could not be suspended and the current lifecycle status could not be verified."
+                )
             return action_result.get_status()
 
         # Add the response into the data section
@@ -558,7 +571,19 @@ class OktaConnector(BaseConnector):
         if phantom.is_fail(ret_val):
             message = action_result.get_message()
             if "Cannot unsuspend a user that is not suspended" in message:
-                return action_result.set_status(phantom.APP_SUCCESS, OKTA_ALREADY_ENABLED_USER_ERR)
+                status_ret_val, user_response = self._make_rest_call(f"/users/{quote(str(user_id), safe='')}", action_result)
+                user_status = user_response.get("status") if phantom.is_success(status_ret_val) and isinstance(user_response, dict) else None
+                if user_status == "ACTIVE":
+                    action_result.update_summary({"user_status": user_status})
+                    return action_result.set_status(phantom.APP_SUCCESS, OKTA_ALREADY_ENABLED_USER_ERR)
+                if user_status:
+                    action_result.update_summary({"user_status": user_status})
+                    return action_result.set_status(
+                        phantom.APP_ERROR, f"User could not be unsuspended: current lifecycle status is {user_status}."
+                    )
+                return action_result.set_status(
+                    phantom.APP_ERROR, "User could not be unsuspended and the current lifecycle status could not be verified."
+                )
             return action_result.get_status()
 
         # Add the response into the data section

--- a/okta_connector.py
+++ b/okta_connector.py
@@ -709,6 +709,7 @@ class OktaConnector(BaseConnector):
 
         # Add the response into the data section
         for item in providers_list:
+            item.get("protocol", {}).get("credentials", {}).get("client", {}).pop("client_secret", None)
             action_result.add_data(item)
 
         # Add a dictionary that is made up of the most important values from data into the summary

--- a/okta_connector.py
+++ b/okta_connector.py
@@ -254,7 +254,7 @@ class OktaConnector(BaseConnector):
         }
 
         try:
-            r = request_func(url, json=json, data=data, headers=headers, params=params, verify=config.get("verify_server_cert", False))
+            r = request_func(url, json=json, data=data, headers=headers, params=params, verify=config.get("verify_server_cert", True))
         except Exception as e:
             return RetVal(
                 action_result.set_status(phantom.APP_ERROR, f"Error Connecting to server. Details: {self._get_error_message_from_exception(e)}"),

--- a/okta_connector.py
+++ b/okta_connector.py
@@ -942,8 +942,10 @@ class OktaConnector(BaseConnector):
         else:
             return action_result.set_status(phantom.APP_ERROR, UNEXPECTED_RESPONSE_MSG)
 
-        # Return success, no need to set the message, only the status
-        # BaseConnector will create a textual message based off of the summary dictionary
+        factor_result = response_verify_ack.get("factorResult")
+        if factor_result != "SUCCESS":
+            return action_result.set_status(phantom.APP_ERROR, f"Okta push verification did not succeed: {factor_result or 'NO_RESULT'}")
+
         return action_result.set_status(phantom.APP_SUCCESS, "Successfully sent push notification")
 
     def _handle_add_group_user(self, param):

--- a/okta_connector.py
+++ b/okta_connector.py
@@ -292,8 +292,13 @@ class OktaConnector(BaseConnector):
 
         response_list = []
         stop_pagination = False
+        pages_fetched = 0
 
         while not stop_pagination:
+            pages_fetched += 1
+            if pages_fetched > OKTA_MAX_PAGES:
+                action_result.set_status(phantom.APP_ERROR, OKTA_MAX_PAGES_MSG_ERR.format(max_pages=OKTA_MAX_PAGES))
+                return None
             after_count = 0
             # make rest call
             ret_val, response = self._make_rest_call(endpoint, action_result, params=params, headers=headers)

--- a/okta_connector.py
+++ b/okta_connector.py
@@ -274,7 +274,7 @@ class OktaConnector(BaseConnector):
 
         self.save_progress("Connecting to endpoint /users/me to test connectivity")
         # make rest call
-        ret_val, response = self._make_rest_call("/users/me", action_result, params=None, headers=None)
+        ret_val, _response = self._make_rest_call("/users/me", action_result, params=None, headers=None)
 
         if phantom.is_fail(ret_val):
             self.save_progress(OKTA_TEST_CONNECTIVITY_FAILED)
@@ -776,14 +776,14 @@ class OktaConnector(BaseConnector):
 
         user_id = self._handle_py_ver_compat_for_input_str(param["user_id"])
         role_id = self._handle_py_ver_compat_for_input_str(param["role_id"])
-        ret_val, response = self._make_rest_call(f"/users/{user_id}", action_result, params=None, headers=None)
+        ret_val, _response = self._make_rest_call(f"/users/{user_id}", action_result, params=None, headers=None)
 
         # Check the user is valid or not
         if phantom.is_fail(ret_val):
             return action_result.set_status(phantom.APP_ERROR, OKTA_INVALID_USER_MSG)
 
         # make rest call
-        ret_val, response = self._make_rest_call(f"/users/{user_id}/roles/{role_id}", action_result, method="delete")
+        ret_val, _response = self._make_rest_call(f"/users/{user_id}/roles/{role_id}", action_result, method="delete")
         if phantom.is_fail(ret_val):
             message = action_result.get_message()
             if "Empty response and no information in the header" in message:

--- a/okta_connector.py
+++ b/okta_connector.py
@@ -18,7 +18,7 @@
 import json
 import sys
 import time
-from urllib.parse import unquote
+from urllib.parse import quote, unquote
 
 import phantom.app as phantom
 import requests
@@ -452,7 +452,9 @@ class OktaConnector(BaseConnector):
             params["sendEmail"] = False
 
         # make rest call
-        ret_val, response = self._make_rest_call(f"/users/{user_id}/lifecycle/reset_password", action_result, params=params, method="post")
+        ret_val, response = self._make_rest_call(
+            f"/users/{quote(str(user_id), safe='')}/lifecycle/reset_password", action_result, params=params, method="post"
+        )
 
         if phantom.is_fail(ret_val):
             return action_result.get_status()
@@ -476,7 +478,7 @@ class OktaConnector(BaseConnector):
         request = {"credentials": {"password": {"value": new_password}}}
 
         # make rest call
-        ret_val, response = self._make_rest_call(f"/users/{user_id}", action_result, json=request, method="post")
+        ret_val, response = self._make_rest_call(f"/users/{quote(str(user_id), safe='')}", action_result, json=request, method="post")
 
         if phantom.is_fail(ret_val):
             return action_result.get_status()
@@ -497,7 +499,7 @@ class OktaConnector(BaseConnector):
         user_id = self._handle_py_ver_compat_for_input_str(param["id"])
 
         # make rest call
-        ret_val, response = self._make_rest_call(f"/users/{user_id}/lifecycle/suspend", action_result, method="post")
+        ret_val, response = self._make_rest_call(f"/users/{quote(str(user_id), safe='')}/lifecycle/suspend", action_result, method="post")
 
         if phantom.is_fail(ret_val):
             message = action_result.get_message()
@@ -521,7 +523,7 @@ class OktaConnector(BaseConnector):
         user_id = param["id"]
 
         # make rest call
-        ret_val, response = self._make_rest_call(f"/users/{user_id}/sessions", action_result, method="delete")
+        ret_val, response = self._make_rest_call(f"/users/{quote(str(user_id), safe='')}/sessions", action_result, method="delete")
 
         if phantom.is_fail(ret_val):
             message = action_result.get_message()
@@ -546,7 +548,7 @@ class OktaConnector(BaseConnector):
         user_id = self._handle_py_ver_compat_for_input_str(param["id"])
 
         # make rest call
-        ret_val, response = self._make_rest_call(f"/users/{user_id}/lifecycle/unsuspend", action_result, method="post")
+        ret_val, response = self._make_rest_call(f"/users/{quote(str(user_id), safe='')}/lifecycle/unsuspend", action_result, method="post")
 
         if phantom.is_fail(ret_val):
             message = action_result.get_message()
@@ -570,7 +572,7 @@ class OktaConnector(BaseConnector):
         user_id = self._handle_py_ver_compat_for_input_str(param["user_id"])
 
         # make rest call
-        ret_val, response = self._make_rest_call(f"/users/{user_id}", action_result, params=None, headers=None)
+        ret_val, response = self._make_rest_call(f"/users/{quote(str(user_id), safe='')}", action_result, params=None, headers=None)
 
         if phantom.is_fail(ret_val):
             return action_result.get_status()
@@ -597,7 +599,7 @@ class OktaConnector(BaseConnector):
         group_id = self._handle_py_ver_compat_for_input_str(param["group_id"])
 
         # make rest call
-        ret_val, response = self._make_rest_call(f"/groups/{group_id}", action_result, params=None, headers=None)
+        ret_val, response = self._make_rest_call(f"/groups/{quote(str(group_id), safe='')}", action_result, params=None, headers=None)
 
         if phantom.is_fail(ret_val):
             return action_result.get_status()
@@ -627,7 +629,7 @@ class OktaConnector(BaseConnector):
         user_id = param["user_id"]
 
         # make rest call
-        ret_val, response = self._make_rest_call(f"/users/{user_id}/groups", action_result)
+        ret_val, response = self._make_rest_call(f"/users/{quote(str(user_id), safe='')}/groups", action_result)
 
         if phantom.is_fail(ret_val):
             action_result.set_status(phantom.APP_ERROR, response)
@@ -720,7 +722,7 @@ class OktaConnector(BaseConnector):
 
         user_id = self._handle_py_ver_compat_for_input_str(param["user_id"])
 
-        roles_list = self._get_paginated_results(f"/users/{user_id}/roles", None, action_result, params=None, headers=None)
+        roles_list = self._get_paginated_results(f"/users/{quote(str(user_id), safe='')}/roles", None, action_result, params=None, headers=None)
 
         if roles_list is None:
             return action_result.set_status(
@@ -753,7 +755,9 @@ class OktaConnector(BaseConnector):
             return action_result.set_status(phantom.APP_ERROR, VALUE_LIST_VALIDATION_MSG.format(ROLE_TYPE_VALUE_LIST, "type"))
 
         # make rest call
-        ret_val, response = self._make_rest_call(f"/users/{user_id}/roles", action_result, json={"type": type_param}, method="post")
+        ret_val, response = self._make_rest_call(
+            f"/users/{quote(str(user_id), safe='')}/roles", action_result, json={"type": type_param}, method="post"
+        )
 
         if phantom.is_fail(ret_val):
             message = action_result.get_message()
@@ -776,14 +780,16 @@ class OktaConnector(BaseConnector):
 
         user_id = self._handle_py_ver_compat_for_input_str(param["user_id"])
         role_id = self._handle_py_ver_compat_for_input_str(param["role_id"])
-        ret_val, _response = self._make_rest_call(f"/users/{user_id}", action_result, params=None, headers=None)
+        ret_val, _response = self._make_rest_call(f"/users/{quote(str(user_id), safe='')}", action_result, params=None, headers=None)
 
         # Check the user is valid or not
         if phantom.is_fail(ret_val):
             return action_result.set_status(phantom.APP_ERROR, OKTA_INVALID_USER_MSG)
 
         # make rest call
-        ret_val, _response = self._make_rest_call(f"/users/{user_id}/roles/{role_id}", action_result, method="delete")
+        ret_val, _response = self._make_rest_call(
+            f"/users/{quote(str(user_id), safe='')}/roles/{quote(str(role_id), safe='')}", action_result, method="delete"
+        )
         if phantom.is_fail(ret_val):
             message = action_result.get_message()
             if "Empty response and no information in the header" in message:
@@ -813,7 +819,7 @@ class OktaConnector(BaseConnector):
         factor_type = factor_type.split(" (not yet implemented)")[0]
 
         # get user
-        ret_val, response_user = self._make_rest_call(f"/users/{user_id}", action_result, method="get")
+        ret_val, response_user = self._make_rest_call(f"/users/{quote(str(user_id), safe='')}", action_result, method="get")
         if phantom.is_fail(ret_val):
             self.save_progress(f"[-] Okta /users/{user_id}: {response_user!s}")
             return action_result.get_status()
@@ -821,7 +827,7 @@ class OktaConnector(BaseConnector):
         # get factors
         try:
             user_id = response_user["id"]
-            ret_val, response_factor = self._make_rest_call(f"/users/{user_id}/factors", action_result, method="get")
+            ret_val, response_factor = self._make_rest_call(f"/users/{quote(str(user_id), safe='')}/factors", action_result, method="get")
             if phantom.is_fail(ret_val):
                 self.save_progress(f"[-] get factors /users/{user_id}/factors: {response_factor!s}")
                 return action_result.get_status()
@@ -917,19 +923,21 @@ class OktaConnector(BaseConnector):
         user_id = param["user_id"]
 
         # translate user_id to name:
-        ret_val, response = self._make_rest_call(f"/users/{user_id}", action_result, method="get")
+        ret_val, response = self._make_rest_call(f"/users/{quote(str(user_id), safe='')}", action_result, method="get")
         if phantom.is_fail(ret_val):
             return action_result.set_status(phantom.APP_ERROR, f"Invalid user_id: {user_id}. {response!s}")
         user_name = response["profile"]["login"]
 
         # translate group_id to name:
-        ret_val, response = self._make_rest_call(f"/groups/{group_id}", action_result, method="get")
+        ret_val, response = self._make_rest_call(f"/groups/{quote(str(group_id), safe='')}", action_result, method="get")
         if phantom.is_fail(ret_val):
             return action_result.set_status(phantom.APP_ERROR, f"Invalid group_id: {group_id}")
         group_name = response["profile"]["name"]
 
         # update group membership:
-        ret_val, response = self._make_rest_call(f"/groups/{group_id}/users/{user_id}", action_result, method="put")
+        ret_val, response = self._make_rest_call(
+            f"/groups/{quote(str(group_id), safe='')}/users/{quote(str(user_id), safe='')}", action_result, method="put"
+        )
         if phantom.is_fail(ret_val):
             return action_result.get_status()
 
@@ -955,19 +963,21 @@ class OktaConnector(BaseConnector):
         group_id = param["group_id"]
 
         # translate user_id to name:
-        ret_val, response = self._make_rest_call(f"/users/{user_id}", action_result, method="get")
+        ret_val, response = self._make_rest_call(f"/users/{quote(str(user_id), safe='')}", action_result, method="get")
         if phantom.is_fail(ret_val):
             return action_result.set_status(phantom.APP_ERROR, f"Invalid user_id: {user_id}")
         user_name = response["profile"]["login"]
 
         # translate group_id to name:
-        ret_val, response = self._make_rest_call(f"/groups/{group_id}", action_result, method="get")
+        ret_val, response = self._make_rest_call(f"/groups/{quote(str(group_id), safe='')}", action_result, method="get")
         if phantom.is_fail(ret_val):
             return action_result.set_status(phantom.APP_ERROR, f"Invalid group_id: {group_id}")
         group_name = response["profile"]["name"]
 
         # remove user from group
-        ret_val, response = self._make_rest_call(f"/groups/{group_id}/users/{user_id}", action_result, method="delete")
+        ret_val, response = self._make_rest_call(
+            f"/groups/{quote(str(group_id), safe='')}/users/{quote(str(user_id), safe='')}", action_result, method="delete"
+        )
 
         if phantom.is_fail(ret_val):
             return action_result.get_status()

--- a/okta_consts.py
+++ b/okta_consts.py
@@ -21,6 +21,8 @@ OKTA_RESET_PASSWORD_SUCC = "Successfully created one-time token for user to rese
 OKTA_LIMIT_INVALID_MSG_ERR = "Please provide a valid positive integer value for 'limit' action parameter"
 OKTA_LIMIT_NON_ZERO_POSITIVE_MSG_ERR = "Please provide a valid non-zero positive integer value for 'limit' action parameter"
 OKTA_PAGINATION_MSG_ERR = "Error occurred while fetching paginated response for action: {action_name}. Error Details: {error_detail}"
+OKTA_MAX_PAGES = 1000
+OKTA_MAX_PAGES_MSG_ERR = "Server kept indicating more pages; aborted pagination after {max_pages} pages"
 
 OKTA_DISABLE_USER_SUCC = "Successfully disabled the user"
 OKTA_ALREADY_DISABLED_USER_ERR = "User is already disabled"

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -3,3 +3,4 @@
 * Encode Okta resource identifiers before inserting them into API paths.
 * Escape widget values before inserting them into JavaScript contexts.
 * Enable TLS certificate verification by default for Okta connections.
+* Stop paginated actions when the server exceeds the maximum page count.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -8,3 +8,4 @@
 * Verify the Okta user lifecycle state before reporting enable or disable success.
 * Report rejected, timed-out, or unanswered Okta push verifications as failures.
 * Preserve empty-body HTTP errors when clearing Okta user sessions.
+* Revoke existing sessions and OAuth tokens when disabling an Okta user.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -6,3 +6,4 @@
 * Stop paginated actions when the server exceeds the maximum page count.
 * Exclude identity-provider client secrets from persisted action results.
 * Verify the Okta user lifecycle state before reporting enable or disable success.
+* Report rejected, timed-out, or unanswered Okta push verifications as failures.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * Encode Okta resource identifiers before inserting them into API paths.
+* Escape widget values before inserting them into JavaScript contexts.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -4,3 +4,4 @@
 * Escape widget values before inserting them into JavaScript contexts.
 * Enable TLS certificate verification by default for Okta connections.
 * Stop paginated actions when the server exceeds the maximum page count.
+* Exclude identity-provider client secrets from persisted action results.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -5,3 +5,4 @@
 * Enable TLS certificate verification by default for Okta connections.
 * Stop paginated actions when the server exceeds the maximum page count.
 * Exclude identity-provider client secrets from persisted action results.
+* Verify the Okta user lifecycle state before reporting enable or disable success.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,3 @@
 **Unreleased**
 
-* - Chore: refresh development checks (temporary baseline note).
+* Encode Okta resource identifiers before inserting them into API paths.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -7,3 +7,4 @@
 * Exclude identity-provider client secrets from persisted action results.
 * Verify the Okta user lifecycle state before reporting enable or disable success.
 * Report rejected, timed-out, or unanswered Okta push verifications as failures.
+* Preserve empty-body HTTP errors when clearing Okta user sessions.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* - Chore: refresh development checks (temporary baseline note).

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -2,3 +2,4 @@
 
 * Encode Okta resource identifiers before inserting them into API paths.
 * Escape widget values before inserting them into JavaScript contexts.
+* Enable TLS certificate verification by default for Okta connections.


### PR DESCRIPTION
### Bug Fixes

- Encode user, group, and role path segments so caller input cannot change Okta API endpoints (PSAAS-30680).
- Escape all connector widget values used in inline JavaScript contexts (PSAAS-30713, PSAAS-31047).
- Enable TLS certificate verification by default (PSAAS-30853). This changes the asset default; existing assets that require insecure connections must explicitly opt out.
- Remove IdP client secrets from persisted action results (PSAAS-32209).
- Bound pagination at 1,000 pages (PSAAS-32073).
- Verify lifecycle state before reporting enable/disable success, fail rejected or timed-out push checks, preserve empty-body session-clear errors, and revoke sessions and OAuth tokens during disable (PSAAS-32314, PSAAS-32315, PSAAS-32329, PSAAS-32435).

PSAAS-32283 required no branch change: Okta main already declares `new_password` and its result datapath as password-typed in commit 92588b2.

The existing single-use password-reset URL output is intentionally retained. It is the functional result of `receive_type=UI`, allowing an authorized SOAR playbook or operator to deliver the URL to the user out of band; removing that guaranteed output would break existing reset workflows.

Tracking: [PAPP-37966](https://splunk.atlassian.net/browse/PAPP-37966), parent epic ESPM-5228. VULN/FS provenance is recorded in the individual signed commits.

### Verification

- `pre-commit run --all-files`
- `python3 -m py_compile okta_connector.py okta_consts.py`
- JSON parse validation for `okta.json`
- All branch commits are signed and contain Codex attribution.

### Manual Documentation

- [x] I have verified that manual documentation has been updated where appropriate

The generated README was refreshed after the identity-provider secret datapath was removed. No REST handler or authentication method was added.

### Other information

The synchronized patch suggestions were treated as recommendations and adapted to the current connector.

Written by Codex.
