### PR TITLE
fix: remediate Okta connector findings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,13 +27,13 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.22
+    rev: v0.16.1
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.40.7
+    rev: v1.43.2
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.6
+    rev: v2.2.9
     hooks:
       - id: build-docs
         language: python

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ This table lists the configuration variables required to operate Okta. These var
 VARIABLE | REQUIRED | TYPE | DESCRIPTION
 -------- | -------- | ---- | -----------
 **api_key** | required | password | API token |
-**base_url** | required | string | Your organization's url. Example: https://your-org.okta.com |
+**base_url** | required | string | Your organization's HTTPS URL. Example: https://your-org.okta.com |
 **verify_server_cert** | optional | boolean | Verify server certificate |
 
 ### Supported Actions

--- a/README.md
+++ b/README.md
@@ -448,7 +448,6 @@ DATA PATH | TYPE | CONTAINS | EXAMPLE VALUES
 --------- | ---- | -------- | --------------
 action_result.status | string | | success failed |
 action_result.parameter.id | string | `okta user id` | 00uby4va2hynIj0mS0h7 |
-action_result.parameter.new_password | password | | newPassword |
 action_result.data.\*.\_links.activate.href | string | | https://your-org.okta.com/api/v1/users/00uvgl84d0wO31Lr60h7/lifecycle/activate |
 action_result.data.\*.\_links.activate.method | string | | POST |
 action_result.data.\*.\_links.changePassword.href | string | `url` | https://your-org.okta.com/api/v1/users/00uaa8hodkEIHTO1s0h7/credentials/change_password |

--- a/display_get_user.html
+++ b/display_get_user.html
@@ -132,17 +132,17 @@
             {% endfor %}
           </tbody>
         </table>
-      </div>
-    {% else %}
-      <p class="wf-h4-style">Could not retrieve user</p>
-    {% endif %}
-    <br>
-    <!------------------- For each Result END ---------------------->
-  {% endfor %}
-  <!-- loop for each result end -->
-</div>
-<!-- Main Div -->
-<script>
+        </div>
+      {% else %}
+        <p class="wf-h4-style">Could not retrieve user</p>
+      {% endif %}
+      <br>
+      <!------------------- For each Result END ---------------------->
+    {% endfor %}
+    <!-- loop for each result end -->
+  </div>
+  <!-- Main Div -->
+  <script>
   $.extend(true, $.fn.dataTable.defaults, {
       "searching": true,
       "bLengthChange": false,
@@ -161,6 +161,6 @@
     });
     $('.dataTable').DataTable();
 
-</script>
+  </script>
 {% endblock %}
 <!-- Main Start Block -->

--- a/okta.json
+++ b/okta.json
@@ -29,7 +29,7 @@
             "order": 1
         },
         "base_url": {
-            "description": "Your organization's url. Example: https://your-org.okta.com",
+            "description": "Your organization's HTTPS URL. Example: https://your-org.okta.com",
             "data_type": "string",
             "required": true,
             "order": 0

--- a/okta.json
+++ b/okta.json
@@ -1419,13 +1419,6 @@
                     "data_type": "string"
                 },
                 {
-                    "data_path": "action_result.parameter.new_password",
-                    "example_values": [
-                        "newPassword"
-                    ],
-                    "data_type": "password"
-                },
-                {
                     "data_path": "action_result.data.*._links.activate.href",
                     "example_values": [
                         "https://your-org.okta.com/api/v1/users/00uvgl84d0wO31Lr60h7/lifecycle/activate"

--- a/okta_connector.py
+++ b/okta_connector.py
@@ -15,10 +15,11 @@
 #
 #
 # Phantom App imports
+import hashlib
 import json
 import sys
 import time
-from urllib.parse import quote, unquote
+from urllib.parse import quote, unquote, urlparse
 
 import phantom.app as phantom
 import requests
@@ -1128,7 +1129,26 @@ class OktaConnector(BaseConnector):
         config = self.get_config()
 
         self._api_token = config[OKTA_API_TOKEN]
-        self._base_url = self._handle_py_ver_compat_for_input_str(config[OKTA_BASE_URL])
+        self._base_url = self._handle_py_ver_compat_for_input_str(config[OKTA_BASE_URL]).rstrip("/")
+
+        parsed_base_url = urlparse(self._base_url)
+        if parsed_base_url.scheme.lower() != "https" or not parsed_base_url.hostname:
+            return self.set_status(phantom.APP_ERROR, "The base_url asset setting must be a valid HTTPS URL.")
+
+        token_fingerprint = hashlib.sha256(str(self._api_token).encode("utf-8")).hexdigest()
+        credential_binding = self._state.get("credential_binding")
+        if (
+            isinstance(credential_binding, dict)
+            and credential_binding.get("token_fingerprint") == token_fingerprint
+            and credential_binding.get("base_url") != self._base_url
+        ):
+            return self.set_status(
+                phantom.APP_ERROR,
+                "The base_url asset setting changed while the stored API token remained unchanged. "
+                "Enter a new API token to authorize the new endpoint.",
+            )
+
+        self._state["credential_binding"] = {"base_url": self._base_url, "token_fingerprint": token_fingerprint}
 
         # The current version of this app as defined in the app json
         self._app_version = self.get_app_json().get("app_version", "")

--- a/okta_connector.py
+++ b/okta_connector.py
@@ -514,6 +514,32 @@ class OktaConnector(BaseConnector):
         # BaseConnector will create a textual message based off of the summary dictionary
         return action_result.set_status(phantom.APP_SUCCESS, OKTA_SET_PASSWORD_SUCC)
 
+    def _get_owned_suspensions(self, action_result):
+        try:
+            installation_id = self.get_product_installation_id()
+        except Exception as e:
+            action_result.set_status(
+                phantom.APP_ERROR,
+                f"Unable to determine suspension ownership. Details: {self._get_error_message_from_exception(e)}",
+            )
+            return None
+
+        if not installation_id:
+            action_result.set_status(phantom.APP_ERROR, "Unable to determine suspension ownership for this SOAR installation.")
+            return None
+
+        ownership_by_installation = self._state.setdefault("suspended_users_by_installation", {})
+        if not isinstance(ownership_by_installation, dict):
+            action_result.set_status(phantom.APP_ERROR, "Stored suspension ownership data has an unexpected format.")
+            return None
+
+        owned_suspensions = ownership_by_installation.setdefault(str(installation_id), [])
+        if not isinstance(owned_suspensions, list):
+            action_result.set_status(phantom.APP_ERROR, "Stored suspension ownership data has an unexpected format.")
+            return None
+
+        return owned_suspensions
+
     def _handle_disable_user(self, param):
         self.save_progress(f"In action handler for: {self.get_action_identifier()}")
 
@@ -521,6 +547,10 @@ class OktaConnector(BaseConnector):
         action_result = self.add_action_result(ActionResult(dict(param)))
 
         user_id = self._handle_py_ver_compat_for_input_str(param["id"])
+
+        owned_suspensions = self._get_owned_suspensions(action_result)
+        if owned_suspensions is None:
+            return action_result.get_status()
 
         # make rest call
         ret_val, response = self._make_rest_call(f"/users/{quote(str(user_id), safe='')}/lifecycle/suspend", action_result, method="post")
@@ -543,6 +573,9 @@ class OktaConnector(BaseConnector):
                     phantom.APP_ERROR, "User could not be suspended and the current lifecycle status could not be verified."
                 )
             return action_result.get_status()
+
+        if str(user_id) not in owned_suspensions:
+            owned_suspensions.append(str(user_id))
 
         revoke_ret_val, _revoke_response = self._make_rest_call(
             f"/users/{quote(str(user_id), safe='')}/sessions",
@@ -594,6 +627,36 @@ class OktaConnector(BaseConnector):
 
         user_id = self._handle_py_ver_compat_for_input_str(param["id"])
 
+        owned_suspensions = self._get_owned_suspensions(action_result)
+        if owned_suspensions is None:
+            return action_result.get_status()
+
+        status_ret_val, user_response = self._make_rest_call(f"/users/{quote(str(user_id), safe='')}", action_result)
+        if phantom.is_fail(status_ret_val):
+            return action_result.get_status()
+
+        user_status = user_response.get("status") if isinstance(user_response, dict) else None
+        if user_status:
+            action_result.update_summary({"user_status": user_status})
+
+        if user_status == "ACTIVE":
+            if str(user_id) in owned_suspensions:
+                owned_suspensions.remove(str(user_id))
+            return action_result.set_status(phantom.APP_SUCCESS, OKTA_ALREADY_ENABLED_USER_ERR)
+
+        if user_status != "SUSPENDED":
+            if user_status:
+                return action_result.set_status(phantom.APP_ERROR, f"User could not be unsuspended: current lifecycle status is {user_status}.")
+            return action_result.set_status(
+                phantom.APP_ERROR, "User could not be unsuspended and the current lifecycle status could not be verified."
+            )
+
+        if str(user_id) not in owned_suspensions:
+            return action_result.set_status(
+                phantom.APP_ERROR,
+                f"Refusing to enable user '{user_id}' because this SOAR installation did not record the suspension.",
+            )
+
         # make rest call
         ret_val, response = self._make_rest_call(f"/users/{quote(str(user_id), safe='')}/lifecycle/unsuspend", action_result, method="post")
 
@@ -603,6 +666,7 @@ class OktaConnector(BaseConnector):
                 status_ret_val, user_response = self._make_rest_call(f"/users/{quote(str(user_id), safe='')}", action_result)
                 user_status = user_response.get("status") if phantom.is_success(status_ret_val) and isinstance(user_response, dict) else None
                 if user_status == "ACTIVE":
+                    owned_suspensions.remove(str(user_id))
                     action_result.update_summary({"user_status": user_status})
                     return action_result.set_status(phantom.APP_SUCCESS, OKTA_ALREADY_ENABLED_USER_ERR)
                 if user_status:
@@ -614,6 +678,8 @@ class OktaConnector(BaseConnector):
                     phantom.APP_ERROR, "User could not be unsuspended and the current lifecycle status could not be verified."
                 )
             return action_result.get_status()
+
+        owned_suspensions.remove(str(user_id))
 
         # Add the response into the data section
         action_result.add_data(response)

--- a/okta_connector.py
+++ b/okta_connector.py
@@ -538,7 +538,7 @@ class OktaConnector(BaseConnector):
         revoke_ret_val, _revoke_response = self._make_rest_call(
             f"/users/{quote(str(user_id), safe='')}/sessions",
             action_result,
-            params={"oauthTokens": True},
+            params={"oauthTokens": "true"},
             method="delete",
         )
         if phantom.is_fail(revoke_ret_val):
@@ -560,7 +560,12 @@ class OktaConnector(BaseConnector):
         user_id = param["id"]
 
         # make rest call
-        ret_val, response = self._make_rest_call(f"/users/{quote(str(user_id), safe='')}/sessions", action_result, method="delete")
+        ret_val, response = self._make_rest_call(
+            f"/users/{quote(str(user_id), safe='')}/sessions",
+            action_result,
+            params={"oauthTokens": "true"},
+            method="delete",
+        )
 
         if phantom.is_fail(ret_val):
             return action_result.get_status()

--- a/okta_connector.py
+++ b/okta_connector.py
@@ -265,7 +265,15 @@ class OktaConnector(BaseConnector):
         }
 
         try:
-            r = request_func(url, json=json, data=data, headers=headers, params=params, verify=config.get("verify_server_cert", True))
+            r = request_func(
+                url,
+                json=json,
+                data=data,
+                headers=headers,
+                params=params,
+                verify=config.get("verify_server_cert", True),
+                timeout=OKTA_DEFAULT_REQUEST_TIMEOUT,
+            )
         except Exception as e:
             return RetVal(
                 action_result.set_status(phantom.APP_ERROR, f"Error Connecting to server. Details: {self._get_error_message_from_exception(e)}"),
@@ -1195,7 +1203,7 @@ if __name__ == "__main__":
         try:
             login_url = BaseConnector._get_phantom_base_url() + "/login"
             print("Accessing the Login page")
-            r = requests.get(login_url, verify=verify)  # nosemgrep: python.requests.best-practice.use-timeout.use-timeout
+            r = requests.get(login_url, verify=verify, timeout=OKTA_DEFAULT_REQUEST_TIMEOUT)
             csrftoken = r.cookies["csrftoken"]
 
             data = dict()
@@ -1208,9 +1216,7 @@ if __name__ == "__main__":
             headers["Referer"] = login_url
 
             print("Logging into Platform to get the session id")
-            r2 = requests.post(  # nosemgrep: python.requests.best-practice.use-timeout.use-timeout
-                login_url, verify=verify, data=data, headers=headers
-            )
+            r2 = requests.post(login_url, verify=verify, data=data, headers=headers, timeout=OKTA_DEFAULT_REQUEST_TIMEOUT)
             session_id = r2.cookies["sessionid"]
         except Exception as e:
             print("Unable to get session id from the platfrom. Error: " + str(e))

--- a/okta_connector.py
+++ b/okta_connector.py
@@ -679,15 +679,18 @@ class OktaConnector(BaseConnector):
 
         user_id = param["user_id"]
 
-        # make rest call
-        ret_val, response = self._make_rest_call(f"/users/{quote(str(user_id), safe='')}/groups", action_result)
+        groups_list = self._get_paginated_results(
+            f"/users/{quote(str(user_id), safe='')}/groups", None, action_result, params=None, headers=None
+        )
 
-        if phantom.is_fail(ret_val):
-            action_result.set_status(phantom.APP_ERROR, response)
-            return action_result.get_status()
+        if groups_list is None:
+            return action_result.set_status(
+                phantom.APP_ERROR,
+                OKTA_PAGINATION_MSG_ERR.format(action_name=self.get_action_identifier(), error_detail=action_result.get_message()),
+            )
 
         # Add the response into the data section
-        for item in response:
+        for item in groups_list:
             action_result.add_data(item)
 
         summary = action_result.update_summary({})

--- a/okta_connector.py
+++ b/okta_connector.py
@@ -101,11 +101,16 @@ class OktaConnector(BaseConnector):
 
         # You should process the error returned in the json
         error_msg = self._handle_py_ver_compat_for_input_str(r.text.replace("{", "{{").replace("}", "}}"))
-        error_msg = resp_json.get("errorSummary", error_msg)
+        if isinstance(resp_json, dict):
+            error_summary = resp_json.get("errorSummary")
+            if isinstance(error_summary, str):
+                error_msg = error_summary
 
-        error_cause = resp_json.get("errorCauses", [{}])
-        if error_cause:
-            error_msg += ". Error Causes: " + error_cause[0].get("errorSummary", "")
+            error_causes = resp_json.get("errorCauses")
+            if isinstance(error_causes, list) and error_causes and isinstance(error_causes[0], dict):
+                cause_summary = error_causes[0].get("errorSummary")
+                if isinstance(cause_summary, str) and cause_summary:
+                    error_msg += ". Error Causes: " + cause_summary
 
         message = f"Error from server. Status Code: {r.status_code} Data from server: {error_msg}"
 
@@ -131,11 +136,16 @@ class OktaConnector(BaseConnector):
 
         # You should process the error returned in the json
         error_msg = self._handle_py_ver_compat_for_input_str(r.text.replace("{", "{{").replace("}", "}}"))
-        error_msg = resp_json.get("errorSummary", error_msg)
+        if isinstance(resp_json, dict):
+            error_summary = resp_json.get("errorSummary")
+            if isinstance(error_summary, str):
+                error_msg = error_summary
 
-        error_cause = resp_json.get("errorCauses", [{}])
-        if error_cause:
-            error_msg += ". Error Causes: " + error_cause[0].get("errorSummary", "")
+            error_causes = resp_json.get("errorCauses")
+            if isinstance(error_causes, list) and error_causes and isinstance(error_causes[0], dict):
+                cause_summary = error_causes[0].get("errorSummary")
+                if isinstance(cause_summary, str) and cause_summary:
+                    error_msg += ". Error Causes: " + cause_summary
 
         message = f"Error from server. Status Code: {r.status_code} Data from server: {error_msg}"
 

--- a/okta_consts.py
+++ b/okta_consts.py
@@ -13,6 +13,7 @@
 # either express or implied. See the License for the specific language governing permissions
 # and limitations under the License.
 OKTA_BASE_URL = "base_url"
+OKTA_DEFAULT_REQUEST_TIMEOUT = 30
 OKTA_API_TOKEN = "api_key"
 OKTA_PAGINATED_ACTIONS_LIST = ["list_users", "list_user_groups", "list_providers", "list_roles", "get_user_groups"]
 

--- a/okta_consts.py
+++ b/okta_consts.py
@@ -14,7 +14,7 @@
 # and limitations under the License.
 OKTA_BASE_URL = "base_url"
 OKTA_API_TOKEN = "api_key"
-OKTA_PAGINATED_ACTIONS_LIST = ["list_users", "list_user_groups", "list_providers", "list_roles"]
+OKTA_PAGINATED_ACTIONS_LIST = ["list_users", "list_user_groups", "list_providers", "list_roles", "get_user_groups"]
 
 OKTA_RESET_PASSWORD_SUCC = "Successfully created one-time token for user to reset password"  # pragma: allowlist secret
 

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * Return clean connector errors for malformed Okta JSON error responses instead of raising unhandled exceptions.
+* Revoke a user's OAuth and OpenID Connect tokens when clearing their Okta sessions.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -3,3 +3,4 @@
 * Return clean connector errors for malformed Okta JSON error responses instead of raising unhandled exceptions.
 * Revoke a user's OAuth and OpenID Connect tokens when clearing their Okta sessions.
 * Require HTTPS Okta endpoints and a new API token when an asset's endpoint changes.
+* Return all pages of Okta group memberships from the get user groups action.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -2,3 +2,4 @@
 
 * Return clean connector errors for malformed Okta JSON error responses instead of raising unhandled exceptions.
 * Revoke a user's OAuth and OpenID Connect tokens when clearing their Okta sessions.
+* Require HTTPS Okta endpoints and a new API token when an asset's endpoint changes.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Return clean connector errors for malformed Okta JSON error responses instead of raising unhandled exceptions.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -5,3 +5,4 @@
 * Require HTTPS Okta endpoints and a new API token when an asset's endpoint changes.
 * Return all pages of Okta group memberships from the get user groups action.
 * Time out unresponsive Okta and local development requests after 30 seconds.
+* Refuse to enable users unless this SOAR installation recorded their Okta suspension.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -4,3 +4,4 @@
 * Revoke a user's OAuth and OpenID Connect tokens when clearing their Okta sessions.
 * Require HTTPS Okta endpoints and a new API token when an asset's endpoint changes.
 * Return all pages of Okta group memberships from the get user groups action.
+* Time out unresponsive Okta and local development requests after 30 seconds.


### PR DESCRIPTION
### Bug Fixes

- Handle malformed Okta JSON error responses without raising unhandled connector exceptions (PSAAS-34372 / VULN-101895 / FS-7879).
- Revoke OAuth and OpenID Connect tokens when clearing a user's sessions (PSAAS-34458 / VULN-101982 / FS-7965).
- Require HTTPS Okta endpoints and bind API tokens to the configured endpoint (PSAAS-34548 / VULN-102072 / FS-8055).
- Follow Okta pagination when retrieving a user's group memberships (PSAAS-34615 / VULN-102139 / FS-8122).
- Apply a 30-second timeout to Okta and local development HTTP requests (PSAAS-34676 / VULN-102200 / FS-8183).
- Enable only users whose suspension was recorded by this SOAR installation (PSAAS-34813 / VULN-102337 / FS-8320).

### Manual Documentation

<details><summary>
Have you made any changes that should be documented in manual_readme_content.md?
</summary><br />

The following changes require documentation in `manual_readme_content.md`:

- New, updated, or removed [REST handlers](https://docs.splunk.com/Documentation/SOAR/current/DevelopApps/RESTHandlers)
- New, updated, or removed authentication methods, especially complex methods like OAuth
- Compatibility considerations with respect to deployment types (e.g. actions that cannot be run on cloud or an automation broker)
</details>

- [x] I have verified that no manual documentation update is required; the generated asset configuration documentation was refreshed by the repository hooks.

### Other information

PAPP: PAPP-37966, under ESPM-5228. This PR covers only the six current active Okta connector findings in the frozen campaign snapshot.

Source evidence:

- Okta API overview and error format: https://developer.okta.com/docs/reference/core-okta-api/
- Okta session and token revocation behavior: https://developer.okta.com/docs/guides/revoke-tokens/-/main/
- Okta user-group pagination: https://developer.okta.com/docs/api/openapi/okta-management/management/tags/userresources/other/listusergroups
- Okta user lifecycle transitions: https://developer.okta.com/docs/api/openapi/okta-management/management/tags/userlifecycle/
- Requests timeout behavior: https://requests.readthedocs.io/en/latest/user/advanced/#timeouts

Patch deviations:

- PSAAS-34372 does not add the recommendation's broad catch-all around response processing because that would conceal unrelated programming errors; it validates only the untrusted error payload structure.
- PSAAS-34548 uses a SHA-256 token fingerprint and requires a new token after an endpoint change. Masked-secret preservation makes same-token re-entry indistinguishable, and existing assets establish their binding on the first post-upgrade action.
- PSAAS-34813 scopes suspension ownership to the SOAR installation ID and intentionally provides no force bypass. The recommendation's generated binary artifacts were not applied.

Checks:

- `pre-commit run --all-files` passed, including Docker-backed packaging, linting, static tests, Semgrep, release-note validation, documentation generation, and dependency packaging.
- Python syntax compilation passed.
- SDK pytest is not applicable because this is a legacy `BaseConnector` app; no non-runnable unit-test scaffolding was added.

Breaking changes: none under the connector campaign policy. The endpoint and credential checks are security-motivated validation and do not add or change required connector parameters.

Merge strategy: merge commit only; do not squash.

Written by Codex.

---
Please refer to our [Contribution Guide](https://github.com/splunk-soar-connectors/.github/blob/main/.github/CONTRIBUTING.md) for any questions on submitting a pull request.

Thanks for contributing!
